### PR TITLE
Bugfix/delay

### DIFF
--- a/src/tesserae/impl.clj
+++ b/src/tesserae/impl.clj
@@ -343,7 +343,7 @@
   (Tessera. (CountDownLatch. 1)
             nil
             (volatile! ::ex/init)
-            (atom {:status :ready})
+            (atom {:status :pending})
             f
             ex-m/delay-model
             (Object.)

--- a/test/tesserae/core_test.clj
+++ b/test/tesserae/core_test.clj
@@ -4,6 +4,14 @@
   (:import [tesserae.impl Tessera]
            [java.util.concurrent CancellationException]))
 
+(deftest test:delay-delays
+  (let [a (atom 0)
+        t (tess/delay (do (swap! a inc)
+                          10))]
+    (is (= 0 @a))
+    (is (= 10 @t))
+    (is (= 1 @a))))
+
 (deftest test:fulfilment-methods
   (let [p-1 (promise)
         p-2 (promise) 


### PR DESCRIPTION
The initialization of a new delay had a silly bug. The tests were testing only delay-model chaining, not regular construction.